### PR TITLE
feat: close all tabs in search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ato",
-  "version": "1.1.0",
+  "version": "1.6.0",
   "description": "Advanced Tab Organizer - Kill duplicate tabs instantly",
   "author": "Jean Lucas Lima",
   "private": true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "ATO - Advanced Tab Organizer",
   "short_name": "ATO",
   "description": "Kill duplicate tabs instantly. Stay focused.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Jean Lucas Lima <github.com/jeanlucaslima>",
 
   "options_page": "options/options.html",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -260,6 +260,14 @@ body {
   margin-bottom: 10px;
 }
 
+#close-search-results-btn {
+  margin-left: auto;
+}
+
+#close-search-results-btn.hidden {
+  display: none;
+}
+
 .search-results-list {
   display: flex;
   flex-direction: column;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -85,6 +85,12 @@
       <div class="search-results-header">
         <h2 class="section-title">Search Results</h2>
         <span class="section-count" id="search-results-section-count">0</span>
+        <button class="btn-action btn-danger" id="close-search-results-btn" title="Close all tabs in search results">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+          </svg>
+          <span>Close results</span>
+        </button>
       </div>
       <div id="search-results-list" class="search-results-list">
         <!-- Populated by JS -->

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -62,6 +62,7 @@ const searchResultsContainerEl = document.getElementById('search-results-contain
 const searchResultsListEl = document.getElementById('search-results-list');
 const searchResultsSectionCountEl = document.getElementById('search-results-section-count');
 const searchEmptyStateEl = document.getElementById('search-empty-state');
+const closeSearchResultsBtn = document.getElementById('close-search-results-btn');
 
 // Settings (loaded from chrome.storage.sync)
 let settings = {
@@ -1097,6 +1098,51 @@ async function closeAllDuplicates() {
   }
 }
 
+/**
+ * Closes all tabs currently shown in the search results.
+ * Honors protectPinned / protectGroups, never closes the active tab,
+ * and skips browser-internal URLs that Chrome won't let extensions close.
+ */
+async function closeAllSearchResults() {
+  try {
+    if (!searchResultTabIds || searchResultTabIds.length === 0) return;
+
+    const idSet = new Set(searchResultTabIds);
+    const allTabs = await chrome.tabs.query({});
+    let tabsToClose = allTabs.filter(tab => idSet.has(tab.id));
+
+    const activeTabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const activeTabId = activeTabs[0]?.id;
+    tabsToClose = tabsToClose.filter(tab => tab.id !== activeTabId);
+
+    if (settings.protectPinned) {
+      tabsToClose = tabsToClose.filter(tab => !tab.pinned);
+    }
+    if (settings.protectGroups) {
+      tabsToClose = tabsToClose.filter(tab => tab.groupId === -1 || tab.groupId === undefined);
+    }
+    tabsToClose = tabsToClose.filter(tab => !isBrowserUrl(tab.url));
+
+    const tabIdsToClose = tabsToClose.map(tab => tab.id);
+    if (tabIdsToClose.length === 0) {
+      await loadAndRender();
+      return;
+    }
+
+    const closedCount = tabIdsToClose.length;
+    await chrome.tabs.remove(tabIdsToClose);
+    log(`✅ Closed ${closedCount} search-result tabs`);
+
+    lastClosedCount = closedCount;
+    undoContext = 'search';
+    showUndoButton('search');
+
+    await loadAndRender();
+  } catch (err) {
+    error('❌ Error closing search results:', err);
+  }
+}
+
 // Render domain filter
 function renderDomainFilter(tabs) {
   allDomainGroups = groupTabsByDomain(tabs);
@@ -1263,6 +1309,7 @@ function render(tabs, duplicates) {
     searchEmptyStateEl.classList.add('hidden');
     searchResultsListEl.innerHTML = '';
     searchResultsSectionCountEl.textContent = searchResults.size;
+    closeSearchResultsBtn.classList.remove('hidden');
 
     // Use cached single-pass computation
     const { urlCounts } = computeRenderData(tabs);
@@ -1297,11 +1344,13 @@ function render(tabs, duplicates) {
     searchResultsSectionCountEl.textContent = '0';
     searchResultTabIds = [];
     highlightedResultIndex = -1;
+    closeSearchResultsBtn.classList.add('hidden');
   } else {
     // Hide search results section when not searching
     searchResultsContainerEl.classList.add('hidden');
     searchResultTabIds = [];
     highlightedResultIndex = -1;
+    closeSearchResultsBtn.classList.add('hidden');
   }
 
   // Use cached single-pass computation
@@ -1558,6 +1607,7 @@ async function loadAndRender() {
 
 // Event Listeners
 closeAllBtn.addEventListener('click', closeAllDuplicates);
+closeSearchResultsBtn.addEventListener('click', closeAllSearchResults);
 
 // Global search event listeners
 globalSearchInputEl.addEventListener('input', handleSearchInput);


### PR DESCRIPTION
Closes #41

## Summary
- Adds a "Close results" button to the search-results header that closes every tab in the current search result set.
- Honors `protectPinned` / `protectGroups`, never closes the active tab, and skips `chrome://` URLs — mirrors the "Close duplicates" UX.
- Reuses the shared undo flow (`showUndoButton` + sessions API restore).
- Button visibility is toggled in all three search render branches (results / empty / inactive).
- Bumps version to 1.6.0.

## Test plan
- [ ] `npm run build` and reload the unpacked extension
- [ ] Open ~5 tabs, type a query that matches 3+ tabs, verify the button appears with the count
- [ ] Click "Close results": matching non-active, non-pinned, non-grouped, non-`chrome://` tabs close; active tab survives; badge updates
- [ ] Click undo: closed tabs are restored
- [ ] Toggle `protectPinned` / `protectGroups` in options and re-test — protected matches are skipped
- [ ] Clear the search input — button and container hide
- [ ] Search query with zero matches — button hides, empty state shows
- [ ] `npm test` passes (112 tests)